### PR TITLE
systemd 235 ignore double exclamation mark

### DIFF
--- a/mkinitcpio-install.sh
+++ b/mkinitcpio-install.sh
@@ -84,7 +84,7 @@ add_systemd_unit_X() {
                 # don't add binaries unless they are required
                 if [[ ${values[0]:0:1} != '-' ]]; then
                     local target=
-                    target=${values[0]} 
+                    target=${values[0]#\!\!} 
                     if [[ -f $BUILDROOT$target ]] ; then
                          quiet "reuse present binary $target"
                     else
@@ -98,7 +98,7 @@ add_systemd_unit_X() {
                 # format:
                 # InitrdBinary=/path/exec [source=/host/exec] [replace=yes] [optional=yes]
                 local source= target= args= replace= optional=
-                target=${values[0]} ; args=${values[@]:1:9}
+                target=${values[0]#\!\!} ; args=${values[@]:1:9}
                 [[ $args ]] && local ${args[*]}
                 [[ $source ]] || source="$target"
                 if [[ -f $BUILDROOT$target ]] ; then


### PR DESCRIPTION
Ignore https://github.com/systemd/systemd/blob/c1719d8bc924ed59448616bd748671c5c7a66d93/NEWS#L131 to resolve these errors:
- ERROR: file not found: `!!/usr/lib/systemd/systemd-networkd'
- ERROR: file not found: `!!/usr/lib/systemd/systemd-resolved'