### PR TITLE
Re-enable root login via password

### DIFF
--- a/initrd-build.sh
+++ b/initrd-build.sh
@@ -25,6 +25,11 @@ do_secret_clean() {
     done
 }
 
+# re-enable root login via password for initramfs only
+do_root_login_enable() {
+    run_command sed -i -r -e 's/(^root:)!(.*)/\1\2/' $BUILDROOT/etc/shadow
+}
+
 # ensure dropbear server host keys
 do_dropbear_keys() {
 

--- a/initrd-shell.service
+++ b/initrd-shell.service
@@ -39,6 +39,10 @@ InitrdPath=/etc/shadow replace=yes
 InitrdBuild=/etc/systemd/system/initrd-build.sh command=do_root_shell
 InitrdBuild=/etc/systemd/system/initrd-build.sh command=do_secret_clean
 
+# enable root password login (dropbear only. Remove -s from ExecStart in 
+# initrd-dropbear.service too)
+#InitrdBuild=/etc/systemd/system/initrd-build.sh command=do_root_login_enable
+
 # include ssh credentials
 InitrdPath=/root/.ssh/authorized_keys source=/root/.ssh/authorized_keys mode=600
 


### PR DESCRIPTION
"root" login via password should be disabled by default on production systems for security reasons.

In the case of a headless system which rootfs is password encrypted, for example using LVM on LUKS, the user will need to login via SSH to give the LUKS password in order to resume the boot sequence. Since opening a LUKS container requires "root" privileges, the user will have to get these one way or another. Logging in directly as "root" using keys is then a good option.

Keys however come with their own constraints and challenges (think: management) and in the case of a system for which you will still have to give a password to unlock the LUKS container, they might be overkill. In that corner case, logging in as "root" with a password (enabled ONLY for the initramfs) becomes an acceptable solution.