### PR TITLE
Makefile and FHS compliance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+PREFIX ?= /usr/local
+SYSTEMD_SYSTEM_PATH ?= /usr/lib
+
+install:
+	install -vDm 644 fstab -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/config
+	install -vDm 644 crypttab -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/config
+	install -vDm 644 initrd-network.network -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/network/
+	install -vDm 755 mkinitcpio-hook.sh $(DESTDIR)$(PREFIX)/lib/initcpio/hooks/systemd-tool
+	install -vDm 755 mkinitcpio-install.sh $(DESTDIR)$(PREFIX)/lib/initcpio/install/systemd-tool
+	install -vDm 755 initrd-build.sh -t $(DESTDIR)$(PREFIX)/lib/mkinitcpio-systemd-tool
+	install -vDm 755 initrd-shell.sh -t $(DESTDIR)$(PREFIX)/lib/mkinitcpio-systemd-tool
+	install -vDm 644 *.{path,service} -t $(DESTDIR)$(SYSTEMD_SYSTEM_PATH)/systemd/system
+	install -vDm 644 LICENSE.md -t $(DESTDIR)$(PREFIX)/share/licenses/mkinitcpio-systemd-tool
+	install -vDm 644 {reference,README}.md -t $(DESTDIR)$(PREFIX)/share/doc/mkinitcpio-systemd-tool

--- a/crypttab
+++ b/crypttab
@@ -1,7 +1,7 @@
 # This file is part of https://github.com/random-archer/mkinitcpio-systemd-tool
 
 # crypttab: mappings for encrypted partitions in initramfs
-# file location in real root: /etc/mkinitcpio.d/crypttab
+# file location in real root: /etc/mkinitcpio-systemd-tool/config/crypttab
 # file location in initramfs: /etc/crypttab
 
 # crypttab format:

--- a/fstab
+++ b/fstab
@@ -1,7 +1,7 @@
 # This file is part of https://github.com/random-archer/mkinitcpio-systemd-tool
 
 # fstab: mappings for direct partitions in initramfs 
-# file location in real root: /etc/mkinitcpio.d/fstab
+# file location in real root: /etc/mkinitcpio-systemd-tool/config/fstab
 # file location in initramfs: /etc/fstab
 
 # fstab format:

--- a/initrd-cryptsetup.service
+++ b/initrd-cryptsetup.service
@@ -19,7 +19,7 @@ Before=cryptsetup.target
 Requires=initrd-shell.service
 
 [Service]
-ExecStart=/etc/systemd/system/initrd-shell.sh script_entry=service service_name=cryptsetup
+ExecStart=/usr/lib/mkinitcpio-systemd-tool/initrd-shell.sh script_entry=service service_name=cryptsetup
 Restart=on-failure
 RestartSec=1s
 RestartPreventExitStatus=100
@@ -31,8 +31,8 @@ TTYPath=/dev/console
 [X-SystemdTool]
 
 # provision disk tables in initramfs
-InitrdPath=/etc/crypttab source=/etc/mkinitcpio.d/crypttab replace=yes
-InitrdPath=/etc/fstab    source=/etc/mkinitcpio.d/fstab    replace=yes
+InitrdPath=/etc/crypttab source=/etc/mkinitcpio-systemd-tool/config/crypttab replace=yes
+InitrdPath=/etc/fstab    source=/etc/mkinitcpio-systemd-tool/config/fstab    replace=yes
 
 # provide folder for sysroot.mount 
 InitrdPath=/sysroot/    create=yes

--- a/initrd-dropbear.service
+++ b/initrd-dropbear.service
@@ -41,7 +41,7 @@ WantedBy=sysinit.target
 InitrdService=disable
 
 # ensure dropbear server host keys
-#InitrdBuild=/etc/systemd/system/initrd-build.sh command=do_dropbear_keys
+#InitrdBuild=/usr/lib/mkinitcpio-systemd-tool/initrd-build.sh command=do_dropbear_keys
 
 # include generated dropbear configuration
 InitrdPath=/etc/dropbear

--- a/initrd-network.service
+++ b/initrd-network.service
@@ -35,7 +35,7 @@ InitrdService=enable
 #InitrdPath=/usr/lib/udev/rules.d/80-net-setup-link.rules
 
 # include network activated in initramfs 
-InitrdPath=/etc/systemd/network/initrd-network.network
+InitrdPath=/etc/systemd/network/initrd-network.network source=/etc/mkinitcpio-systemd-tool/network/initrd-network.network
 
 # provision discovered network kernel modules 
 InitrdCall=add_checked_modules /drivers/net/

--- a/initrd-shell.service
+++ b/initrd-shell.service
@@ -23,25 +23,25 @@ WantedBy=sysinit.target
 InitrdService=enable
 
 # provision initrd shell
-InitrdPath=/etc/systemd/system/initrd-shell.sh mode=700
+InitrdPath=/usr/lib/mkinitcpio-systemd-tool/initrd-shell.sh mode=700
 InitrdBinary=/usr/bin/sulogin
 InitrdBinary=/usr/bin/systemctl
 InitrdBinary=/usr/bin/systemd-cat
 InitrdBinary=/usr/bin/journalctl
 
 # configure login script
-InitrdLink=/root/.profile /etc/systemd/system/initrd-shell.sh
+InitrdLink=/root/.profile /usr/lib/mkinitcpio-systemd-tool/initrd-shell.sh
 
 # configure user settings
 InitrdPath=/etc/group  replace=yes
 InitrdPath=/etc/passwd replace=yes
 InitrdPath=/etc/shadow replace=yes
-InitrdBuild=/etc/systemd/system/initrd-build.sh command=do_root_shell
-InitrdBuild=/etc/systemd/system/initrd-build.sh command=do_secret_clean
+InitrdBuild=/usr/lib/mkinitcpio-systemd-tool/initrd-build.sh command=do_root_shell
+InitrdBuild=/usr/lib/mkinitcpio-systemd-tool/initrd-build.sh command=do_secret_clean
 
 # enable root password login (dropbear only. Remove -s from ExecStart in 
 # initrd-dropbear.service too)
-#InitrdBuild=/etc/systemd/system/initrd-build.sh command=do_root_login_enable
+#InitrdBuild=/usr/lib/mkinitcpio-systemd-tool/initrd-build.sh command=do_root_login_enable
 
 # include ssh credentials
 InitrdPath=/root/.ssh/authorized_keys source=/root/.ssh/authorized_keys mode=600

--- a/initrd-tinysshd.service
+++ b/initrd-tinysshd.service
@@ -37,7 +37,7 @@ WantedBy=sysinit.target
 InitrdService=enable
 
 # ensure tinyssh keys are based on openssh keys
-InitrdBuild=/etc/systemd/system/initrd-build.sh command=do_tinysshd_keys
+InitrdBuild=/usr/lib/mkinitcpio-systemd-tool/initrd-build.sh command=do_tinysshd_keys
 
 # provision tinyssh server
 InitrdBinary=/usr/bin/tinysshd

--- a/mkinitcpio-install.sh
+++ b/mkinitcpio-install.sh
@@ -24,7 +24,7 @@ build() {
     add_dir $dir
     
     # locate units marked for inclusion into initramfs
-    local unit_list=$(2>/dev/null grep -l -F "$tag" "$dir"/*)
+    local unit_list=$(2>/dev/null grep -R -l -F "$tag" "$dir"/*)
     [[ $unit_list ]] || error "Missing any units in $dir with entry $tag"
 
     local unit


### PR DESCRIPTION
To be able to package this project properly, it needs to become [FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) compliant.

For this purpose I have created a Makefile, that installs the various files to their correct locations.
Certain files had to be relocated, due to their nature (e.g. scripts are not allowed in /etc, services need to be packaged to /usr/lib, network configuration for initrd should not influence the running system) and I think that mkinitcpio-install.sh potentially needs some further adjustments to make this work (feedback is of course very much welcome!).

Ideally the script should derive whatever is enabled or overridden by `systemctl cat <service>` instead of relying on a hardcoded path and then assemble the required files and services.