### PR TITLE
Respect enabled services and dropins, fix grep.

### DIFF
--- a/initrd-cryptsetup.path
+++ b/initrd-cryptsetup.path
@@ -10,6 +10,8 @@ DefaultDependencies=no
 Conflicts=shutdown.target
 After=plymouth-start.service
 Before=paths.target shutdown.target
+# require explicitly to include in initramfs image
+Requires=initrd-cryptsetup.service
 
 [Path]
 MakeDirectory=yes


### PR DESCRIPTION
- grep only for **enabled** units and dropin files
- grep for exact match to avoid commented-out lines
- grep for one match, then continue
- check if service of dropin is actually enabled
- add dropin configuration of enabled units
- loop over `systemd cat` output to add dropin binaries as well
- ignore empty `Exec*` override keys

Previously the script tried to include `*.pacsave` files that were left after the latest upgrade for anyone who edited these files. Now since we only consider enabled services and match for only two file extensions this can't happen anymore.

Also it is no longer required to `edit --full` a service to add it, a drop-in will do the job.