### PR TITLE
review sysroot mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,24 +44,31 @@ Useful issues [resolved in the past](https://github.com/random-archer/mkinitcpio
 
 Basic usage steps:
 
+1) study and practice [system recovery](https://github.com/random-archer/mkinitcpio-systemd-tool/wiki/System-Recovery)<br/>
+as practice shows configuration errors do occur
+
+2) install the package
 ```
 pacman -S mkinitcpio-systemd-tool
 ```
 
-1) activate required hooks in `/etc/mkinitcpio.conf`:
+3) activate required hooks in `/etc/mkinitcpio.conf`:
 ```
 HOOKS="base ... systemd systemd-tool"
 ```
 
-2) configure, override and enable/disable [provided units](https://github.com/random-archer/mkinitcpio-systemd-tool/tree/master/src), for example: <br/>
+4) configure, override and enable/disable [provided units](https://github.com/random-archer/mkinitcpio-systemd-tool/tree/master/src), for example: <br/>
 for remote unlocking of luks root with `cryptsetup` and `tinysshd` use:
 ```
 edit /etc/mkinitcpio-systemd-tool/config/crypttab
 edit /etc/mkinitcpio-systemd-tool/config/fstab
-systemctl enable initrd-cryptsetup.path initrd-tinysshd.service
+systemctl enable initrd-cryptsetup.path
+systemctl enable initrd-tinysshd.service
+systemctl enable initrd-debug-progs.service
+systemctl enable initrd-sysroot-mount.service
 ```
 
-3) build image, review content and finally reboot:
+5) build image, review content and finally reboot:
 ```
 mkinitcpio -v -p linux > build.log
 lsinitcpio -x /boot/initramfs-linux.img
@@ -107,7 +114,7 @@ how systemd unit transitive dependency provisioning works?
 what is the purpose of `[X-SystemdTool]` section in service unit files?
 * see https://github.com/systemd/systemd/issues/3340
 * this section provides configuration interface for `mkinitcpio` provisioning actions
-* supported directives: `InitrdPath` `InitrdLink` `InitrdBinary` `InitrdBuild` `InitrdCall`
+* directives: `InitrdPath` `InitrdLink` `InitrdBinary` `InitrdBuild` `InitrdCall` `InitrdUnit` 
 
 how can I auto-provision my custom service unit binaries into initramfs?
 * use `InitrdBinary=/path/target-exec` to provision service binary

--- a/src/mkinitcpio-install.sh
+++ b/src/mkinitcpio-install.sh
@@ -158,14 +158,13 @@ add_systemd_unit_X() {
         read -ra entry_list <<< "$entry_list"
 
         case $directive in
-            Requires|Requisite|BindsTo|OnFailure|Unit)
+            Requires|OnFailure|Unit|InitrdUnit)
                 # only add hard dependencies (not wants) 
                 # from [secion] / directive:
                 # [Unit] / Requires=
-                # [Unit] / Requisite=
-                # [Unit] / BindsTo=
                 # [Unit] / OnFailure=
                 # [Path] / Unit=
+                # [X-SystemdTool] / InitrdUnit= provision units as is
                 map add_systemd_unit_X ${entry_list[*]}
                 ;;
             Exec*)

--- a/tool/image/test/cryptsetup/verify.py
+++ b/tool/image/test/cryptsetup/verify.py
@@ -23,6 +23,7 @@ machine.install_tool()
 machine.service_enable_list([
     "initrd-cryptsetup.path",
     "initrd-debug-progs.service",
+    "initrd-sysroot-mount.service",
 ])
 
 # machine.service_mask("systemd-udevd.service")
@@ -35,6 +36,8 @@ path_list = [
     "/usr/lib/systemd/system/initrd-cryptsetup.service",
 
     "/usr/lib/systemd/system/initrd-shell.service",
+
+    "/usr/lib/systemd/system/initrd-sysroot-mount.service",
 
     "/root/.ssh/authorized_keys",
     "/usr/lib/mkinitcpio-systemd-tool/initrd-shell.sh",
@@ -56,7 +59,7 @@ path_list = [
     "/usr/lib/systemd/systemd-cryptsetup",
     "/usr/lib/systemd/system-generators/systemd-cryptsetup-generator",
     "/usr/lib/systemd/system-generators/systemd-fstab-generator",
-
+    
 ]
 
 link_list = [
@@ -64,6 +67,9 @@ link_list = [
     "/root/.profile",
 
     "/etc/systemd/system/sysinit.target.wants/initrd-cryptsetup.path",
+    "/etc/systemd/system/sysinit.target.wants/initrd-debug-progs.service",
+    
+    "/etc/systemd/system/initrd-root-fs.target.wants/initrd-sysroot-mount.service",
 
 ]
 


### PR DESCRIPTION
1. revert strong dependency directives
```
        case $directive in
            Requires|OnFailure|Unit|InitrdUnit)
```
2. introduce directive:
```
InitrdUnit
```
3. recommend sysroot mount in readme
```
systemctl enable initrd-cryptsetup.path
systemctl enable initrd-tinysshd.service
systemctl enable initrd-debug-progs.service
systemctl enable initrd-sysroot-mount.service
```