### PR TITLE
support sshd port vars

### DIFF
--- a/src/initrd-dropbear.service
+++ b/src/initrd-dropbear.service
@@ -31,12 +31,16 @@ Requires=initrd-shell.service
 Requires=initrd-network.service
 
 [Service]
+# use service unit override to select a different port
+Environment=SSHD_PORT=22
+#
 # dropbear options:
 # -s     Disable password logins.
 # -j     Disable local port forwarding.
 # -k     Disable remote port forwarding.
 # -F     Don't fork into background.
-ExecStart=/bin/dropbear -s -j -k -F
+# -p     Listen on specified TCP port
+ExecStart=/bin/dropbear -s -j -k -F -p ${SSHD_PORT}
 ExecReload=/bin/kill -HUP ${MAINPID}
 # dropbear reports 1 when exiting on SIGTERM
 SuccessExitStatus= 0 1
@@ -68,7 +72,7 @@ InitrdPath=/var/log/lastlog create=yes
 #
 #[Service] 
 #ExecStart=
-#ExecStart=/bin/dropbear -j -k -F
+#ExecStart=/bin/dropbear -j -k -F -p ${SSHD_PORT}
 #
 #[X-SystemdTool]
 #InitrdBuild=/usr/lib/mkinitcpio-systemd-tool/initrd-build.sh command=do_root_login_enable

--- a/src/initrd-tinysshd.service
+++ b/src/initrd-tinysshd.service
@@ -27,7 +27,10 @@ Requires=initrd-shell.service
 Requires=initrd-network.service
 
 [Service]
-ExecStart=/usr/bin/busybox tcpsvd -v 0 22 /usr/bin/tinysshd -v /etc/tinyssh/sshkeydir
+# use service unit override to select a different port
+Environment=SSHD_PORT=22
+#
+ExecStart=/usr/bin/busybox tcpsvd -v 0 ${SSHD_PORT} /usr/bin/tinysshd -v /etc/tinyssh/sshkeydir
 Restart=always
 RestartSec=3s
 

--- a/tool/image/test/dropbear/etc/systemd/system/initrd-dropbear.service.d/override.conf
+++ b/tool/image/test/dropbear/etc/systemd/system/initrd-dropbear.service.d/override.conf
@@ -1,9 +1,17 @@
 
-# enable password logins
 
-[Service] 
+[Service]
+
+# change port number
+
+Environment=SSHD_PORT=221
+
+# enable password logins
+ 
 ExecStart=
-ExecStart=/bin/dropbear -j -k -F
+ExecStart=/bin/dropbear -j -k -F -p ${SSHD_PORT}
 
 [X-SystemdTool]
+
+
 InitrdBuild=/usr/lib/mkinitcpio-systemd-tool/initrd-build.sh command=do_root_login_enable

--- a/tool/image/test/dropbear/test_base/usr/lib/systemd/system/initrd-dropbear.service
+++ b/tool/image/test/dropbear/test_base/usr/lib/systemd/system/initrd-dropbear.service
@@ -32,12 +32,16 @@ Requires=initrd-shell.service
 Requires=initrd-network.service
 
 [Service]
+# use service unit override to select a different port
+Environment=SSHD_PORT=22
+#
 # dropbear options:
 # -s     Disable password logins.
 # -j     Disable local port forwarding.
 # -k     Disable remote port forwarding.
 # -F     Don't fork into background.
-ExecStart=/bin/dropbear -s -j -k -F
+# -p     Listen on specified TCP port
+ExecStart=/bin/dropbear -s -j -k -F -p ${SSHD_PORT}
 ExecReload=/bin/kill -HUP ${MAINPID}
 # dropbear reports 1 when exiting on SIGTERM
 SuccessExitStatus= 0 1
@@ -69,7 +73,7 @@ InitrdPath=/var/log/lastlog create=yes
 #
 #[Service] 
 #ExecStart=
-#ExecStart=/bin/dropbear -j -k -F
+#ExecStart=/bin/dropbear -j -k -F -p ${SSHD_PORT}
 #
 #[X-SystemdTool]
 #InitrdBuild=/usr/lib/mkinitcpio-systemd-tool/initrd-build.sh command=do_root_login_enable
@@ -77,11 +81,19 @@ InitrdPath=/var/log/lastlog create=yes
 
 # /etc/systemd/system/initrd-dropbear.service.d/override.conf
 
-# enable password logins
 
-[Service] 
+[Service]
+
+# change port number
+
+Environment=SSHD_PORT=221
+
+# enable password logins
+ 
 ExecStart=
-ExecStart=/bin/dropbear -j -k -F
+ExecStart=/bin/dropbear -j -k -F -p ${SSHD_PORT}
 
 [X-SystemdTool]
+
+
 InitrdBuild=/usr/lib/mkinitcpio-systemd-tool/initrd-build.sh command=do_root_login_enable

--- a/tool/image/test/tinysshd/etc/systemd/system/initrd-tinysshd.service.d/override.conf
+++ b/tool/image/test/tinysshd/etc/systemd/system/initrd-tinysshd.service.d/override.conf
@@ -1,6 +1,6 @@
 
 [Service]
 
-# change port
-ExecStart=
-ExecStart=/usr/bin/busybox tcpsvd -v 0 222 /usr/bin/tinysshd -v /etc/tinyssh/sshkeydir
+# change port number
+
+Environment=SSHD_PORT=222

--- a/tool/image/test/tinysshd/test_base/usr/lib/systemd/system/initrd-tinysshd.service
+++ b/tool/image/test/tinysshd/test_base/usr/lib/systemd/system/initrd-tinysshd.service
@@ -28,7 +28,10 @@ Requires=initrd-shell.service
 Requires=initrd-network.service
 
 [Service]
-ExecStart=/usr/bin/busybox tcpsvd -v 0 22 /usr/bin/tinysshd -v /etc/tinyssh/sshkeydir
+# use service unit override to select a different port
+Environment=SSHD_PORT=22
+#
+ExecStart=/usr/bin/busybox tcpsvd -v 0 ${SSHD_PORT} /usr/bin/tinysshd -v /etc/tinyssh/sshkeydir
 Restart=always
 RestartSec=3s
 
@@ -54,6 +57,6 @@ InitrdPath=/etc/tinyssh/sshkeydir/ed25519.pk
 
 [Service]
 
-# change port
-ExecStart=
-ExecStart=/usr/bin/busybox tcpsvd -v 0 222 /usr/bin/tinysshd -v /etc/tinyssh/sshkeydir
+# change port number
+
+Environment=SSHD_PORT=222


### PR DESCRIPTION
support environment variables for `initrd-dropbear.service`, `initrd-tinysshd.service`:
```
# use service unit override to select a different port
Environment=SSHD_PORT=22
```
