### PR TITLE
support usb hcd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PREFIX ?= /usr/local
 SYSTEMD_SYSTEM_PATH ?= /usr/lib
 
 install:
+	install -vDm 644 src/*.conf -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/config
 	install -vDm 644 src/fstab -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/config
 	install -vDm 644 src/crypttab -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/config
 	install -vDm 644 src/initrd-network.network -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/network/

--- a/src/initrd-util-usb-hcd.conf
+++ b/src/initrd-util-usb-hcd.conf
@@ -1,0 +1,15 @@
+# This file is part of https://github.com/random-archer/mkinitcpio-systemd-tool
+
+# Provide enhanced configuration for usb keyboard inside initramfs.
+
+# file location in initramfs:
+# /etc/modprobe.d/initrd-util-usb-hcd.conf
+
+# file location in real-root:
+# /etc/mkinitcpio-systemd-tool/config/initrd-util-usb-hcd.conf
+
+# required module load order: xhci-hcd ehci-hcd uhci-hcd ohci-hcd
+
+softdep ehci-hcd pre: xhci-hcd
+softdep uhci-hcd pre: ehci-hcd
+softdep ohci-hcd pre: uhci-hcd

--- a/src/initrd-util-usb-hcd.service
+++ b/src/initrd-util-usb-hcd.service
@@ -1,0 +1,50 @@
+# This file is part of https://github.com/random-archer/mkinitcpio-systemd-tool
+
+# Provide enhanced configuration for usb keyboard inside initramfs.
+
+# note:
+# * sometimes usb drives are not properly detected/loaded for initrd
+# * try to enable this service to see if that resolves the issue 
+
+[Unit]
+Description=Initrd/Util USB-HCD Service
+ConditionPathExists=/etc/initrd-release
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/bin/true
+
+[Install]
+WantedBy=sysinit.target
+
+[X-SystemdTool]
+
+# driver terminology:
+# xhci = eXtensible Host Controller Interface, USB 3.0 
+# ehci = Enhanced Host Controller Interface, USB 2.0
+# *hcd = host controller driver
+# *pci = pci bus glue
+
+#
+# provision usb modules
+#
+
+# http://cateee.net/lkddb/web-lkddb/USB_XHCI_HCD.html
+InitrdCall=add_module xhci_hcd
+InitrdCall=add_module xhci_pci
+
+# http://cateee.net/lkddb/web-lkddb/USB_EHCI_HCD.html
+InitrdCall=add_module ehci_hcd
+InitrdCall=add_module ehci_pci
+
+# http://cateee.net/lkddb/web-lkddb/HID_GENERIC.html
+InitrdCall=add_module hid_generic
+
+#
+# provision module config
+#
+
+# enforce module load order
+InitrdPath=/etc/modprobe.d/initrd-util-usb-hcd.conf source=/etc/mkinitcpio-systemd-tool/config/initrd-util-usb-hcd.conf

--- a/tool/image/test/unitada/verify.py
+++ b/tool/image/test/unitada/verify.py
@@ -22,6 +22,7 @@ machine.install_tool()
 
 machine.service_enable_list([
     "root-entry.mount",
+    "initrd-util-usb-hcd.service",
 ])
 
 machine.produce_boot_result()
@@ -29,6 +30,8 @@ machine.produce_boot_result()
 path_list = [
 
     "/etc/systemd/system/root-entry.mount",
+    
+    "/etc/modprobe.d/initrd-util-usb-hcd.conf",
 
 ]
 
@@ -36,6 +39,8 @@ link_list = [
 
     "/etc/systemd/system/custom-tester.target.wants/root-entry.mount",
     "/etc/systemd/system/super-duper.mount.requires/root-entry.mount",
+
+    "/etc/systemd/system/sysinit.target.wants/initrd-util-usb-hcd.service",
 
 ]
 


### PR DESCRIPTION
new initrd service `initrd-util-usb-hcd.service`
```
# Provide enhanced configuration for usb keyboard inside initramfs.

# note:
# * sometimes usb drives are not properly detected/loaded for initrd
# * try to enable this service to see if that resolves the issue 
```
