### PR TITLE
beeper service

### DIFF
--- a/src/initrd-emergency.service
+++ b/src/initrd-emergency.service
@@ -2,7 +2,7 @@
 
 # Override Emergency Service
 
-# TODO does not work
+# TODO add ssh server dependency
 
 # the default reaction to several failed cryptsetup attempts is to isolate the emergency service
 # which results in loss of network and forced local interactive console - no good for ssh mode 

--- a/src/initrd-emergency.target
+++ b/src/initrd-emergency.target
@@ -2,7 +2,7 @@
 
 # Override Emergency Target
 
-# TODO does not work
+# TODO add ssh server dependency
 
 # the default reaction to several failed cryptsetup attempts is to isolate the emergency service
 # which results in loss of network and forced local interactive console - no good for ssh mode 

--- a/src/initrd-util-pc-beep.service
+++ b/src/initrd-util-pc-beep.service
@@ -1,0 +1,27 @@
+# This file is part of https://github.com/random-archer/mkinitcpio-systemd-tool
+
+# Provide PC Beeper sound during initramfs boot.
+
+# service dependencies:
+# - https://www.archlinux.org/packages/extra/x86_64/beep/
+
+[Unit]
+Description=Initrd Beeper Service
+ConditionPathExists=/etc/initrd-release
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStartPre=/usr/bin/beep -f 700 -r 3 -d 50 -l 200
+ExecStart=/bin/true
+
+[Install]
+WantedBy=sysinit.target
+
+[X-SystemdTool]
+
+# provision beeper components
+# https://wiki.archlinux.org/index.php/PC_speaker#Beep
+InitrdBinary=/usr/bin/beep
+InitrdCall=add_module pcspkr


### PR DESCRIPTION
support beeper:

**`initrd-util-pc-beep.service`**

```
# Provide PC Beeper sound during initramfs boot.

# service dependencies:
# - https://www.archlinux.org/packages/extra/x86_64/beep/

```