### PR TITLE
calling busybox tcpsvd with :: to enable ipv6 for tinyssh

### DIFF
--- a/src/initrd-tinysshd.service
+++ b/src/initrd-tinysshd.service
@@ -30,7 +30,7 @@ Requires=initrd-network.service
 # use service unit override to select a different port
 Environment=SSHD_PORT=22
 #
-ExecStart=/usr/bin/busybox tcpsvd -v 0 ${SSHD_PORT} /usr/bin/tinysshd -v /etc/tinyssh/sshkeydir
+ExecStart=/usr/bin/busybox tcpsvd -v ::  ${SSHD_PORT} /usr/bin/tinysshd -v /etc/tinyssh/sshkeydir
 Restart=always
 RestartSec=3s
 


### PR DESCRIPTION
using :: instead of 0 in the host argument of tcpsvd allows tinyssh to listen for connections for ipv4 and ipv6 connections instead of only ipv4 connections