### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ systemctl enable initrd-sysroot-mount.service
 5) build image, review content and finally reboot:
 ```
 mkinitcpio -v -p linux > build.log
-lsinitcpio -x /boot/initramfs-linux.img
+lsinitcpio -l /boot/initramfs-linux.img
 systemctl reboot
 ```
 


### PR DESCRIPTION
   -l, --list           list contents of the image (default)
   -x, --extract        extract image to disk

-x will extract the initcpio archive, overwriting your current rootfs with it's contents if you execute it while $CWD==/ (which is default after you execute `arch-chroot /your/new/rootfs`)