### PR TITLE
tinyssh-convert behavior changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PREFIX ?= /usr/local
 SYSTEMD_SYSTEM_PATH ?= /usr/lib
 
 install:
-	install -vDm 644 src/*.conf -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/config
+	install -vDm 644 src/{initrd-nftables,initrd-util-usb-hcd}.conf -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/config
 	install -vDm 644 src/fstab -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/config
 	install -vDm 644 src/crypttab -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/config
 	install -vDm 644 src/initrd-network.network -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/network/
@@ -13,3 +13,4 @@ install:
 	install -vDm 644 src/*.{path,service,target} -t $(DESTDIR)$(SYSTEMD_SYSTEM_PATH)/systemd/system
 	install -vDm 644 LICENSE.md -t $(DESTDIR)$(PREFIX)/share/licenses/mkinitcpio-systemd-tool
 	install -vDm 644 README.md -t $(DESTDIR)$(PREFIX)/share/doc/mkinitcpio-systemd-tool
+	install -vDm 644 src/mkinitcpio-systemd-tool.conf -t $(DESTDIR)/etc/mkinitcpio-systemd-tool

--- a/src/mkinitcpio-systemd-tool.conf
+++ b/src/mkinitcpio-systemd-tool.conf
@@ -1,0 +1,4 @@
+# Convert openssh keys for tinysshd on initramfs creation.
+# Default: true
+# Possible parameters: true|false
+openssh_key_convert=true


### PR DESCRIPTION
Since version 20210601 of tinyssh which since today(10-13-2021) is installed on Arch Linux machines.
It contains an own tinyssh-convert. This one behave other then the tinyssh-convert which is usually
used on an Arch Linux installation and since today(10-13-2021) it is removed when installing
the new tinyssh package.

1. First the new tinyssh-convert doesn't generate the keys when key dir already exists.
2. The commandline arguments changed.