### PR TITLE
Add initrd-ntpd.service for timesync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ install:
 	install -vDm 644 src/*.conf -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/config
 	install -vDm 644 src/fstab -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/config
 	install -vDm 644 src/crypttab -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/config
+	install -vDm 644 src/ntp.conf -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/config
 	install -vDm 644 src/initrd-network.network -t $(DESTDIR)/etc/mkinitcpio-systemd-tool/network/
 	install -vDm 755 src/mkinitcpio-hook.sh $(DESTDIR)$(PREFIX)/lib/initcpio/hooks/systemd-tool
 	install -vDm 755 src/mkinitcpio-install.sh $(DESTDIR)$(PREFIX)/lib/initcpio/install/systemd-tool

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -29,6 +29,7 @@ optdepends=('cryptsetup: for initrd-cryptsetup.service'
 conflicts=('mkinitcpio-dropbear' 'mkinitcpio-tinyssh')
 backup=("etc/${pkgname}/config/crypttab"
         "etc/${pkgname}/config/fstab"
+        "etc/${pkgname}/config/ntp.conf"
         "etc/${pkgname}/config/initrd-nftables.conf"
         "etc/${pkgname}/config/initrd-util-usb-hcd.conf"
         "etc/${pkgname}/network/initrd-network.network" )

--- a/src/initrd-ntpd.service
+++ b/src/initrd-ntpd.service
@@ -1,0 +1,34 @@
+# /etc/systemd/system/initrd-ntpd.service
+# This file is part of https://github.com/random-archer/mkinitcpio-systemd-tool
+
+# Provide time syncing in initramfs
+
+# note:
+# - Make sure /etc/mkinitcpio-systemd-tool/config/ntp.conf has server entries
+
+# service dependencies:
+# - https://www.archlinux.org/packages/community/x86_64/busybox/
+
+[Unit]
+Description=Initrd NTPD Service
+Documentation=https://github.com/random-archer/mkinitcpio-systemd-tool/blob/master/README.md
+ConditionPathExists=/etc/initrd-release
+DefaultDependencies=no
+After=initrd-network.service
+Before=cryptsetup-pre.target
+Requires=initrd-network.service
+
+[Service]
+ExecStart=/usr/bin/busybox ntpd -n -q
+Restart=on-failure
+RestartSec=30s
+
+[Install]
+WantedBy=sysinit.target
+
+[X-SystemdTool]
+# use full busybox (provides ntpd applet)
+InitrdBinary=/usr/bin/busybox replace=yes
+
+# include ntp.conf
+InitrdPath=/etc/ntp.conf source=/etc/mkinitcpio-systemd-tool/config/ntp.conf

--- a/src/ntp.conf
+++ b/src/ntp.conf
@@ -1,0 +1,4 @@
+server 0.pool.ntp.org
+server 1.pool.ntp.org
+server 2.pool.ntp.org
+server 3.pool.ntp.org


### PR DESCRIPTION
As I mentioned in a comment on #77, for use-cases such as a connection to WireGuard, an accurate system time is required. The proper solution for what I proposed in my comment is what has resulted in this pull request.

I decided to write a unit file to use the ntpd included in busybox to synchronize the time, since this doesn't require including any new binaries previously not included in the initramfs.