### PR TITLE
disabled await_console_stable for pseudo TTYs

### DIFF
--- a/src/initrd-shell.sh
+++ b/src/initrd-shell.sh
@@ -138,6 +138,8 @@ is_console_stable() {
 
 # ensure console is no longer changing
 await_console_stable() {
+    local tty=$(tty)
+    [[ -z "${tty##/dev/pts/*}" ]] && return 0
     await_condition is_console_stable
 }
 


### PR DESCRIPTION
I use systemd-tool mainly to unlock the LUKS encrypted volumes of my remote server by means of tinysshd. My setup exhibits the annoying behaviour of a 12sec delay before the passphrase prompt appears. For some reason `await_console_stable` always detects changes in the console - even in a pseudo tty (remember tinysshd) where definitely no boot messages interfer. I was unable to track down the root cause of this faulty behaviour. The outputs of `tail -c 256 /dev/vcs` (as used in `read_console_tail`) are identical whenever I run this command by hand. Seams to be a heisenbug.

Anyway: IMHO `await_console_stable` doesn't make any sense with pseudo TTYs. So I simply disabled this function when command `tty` returns something matching `/dev/pts/*`. With this fix whenever I log into my freshly booted machine with SSH I get my passphrase immediately.