### PR TITLE
Added Support for Preserving Additional Users/Groups

### DIFF
--- a/src/mkinitcpio-systemd-tool.conf
+++ b/src/mkinitcpio-systemd-tool.conf
@@ -2,3 +2,10 @@
 # Default: true
 # Possible parameters: true|false
 openssh_key_convert=true
+
+# Preserve additional users and groups in initramfs. Useful for running custom services. 
+# Normally only root, system-.*, and some udev accounts are preserved.
+# Does not create new users or groups. Only copies existing entries from /etc/{passwd,group,shadow}.
+# Default: ()
+# Example: preserve_additional_accounts=("httpd" "avahi" "user1")
+preserve_additional_accounts=()


### PR DESCRIPTION
do_secret_clean() in initrd-build.sh wipes all user accounts besides a hard coded list. If a user would like to add a service that needs to run as a specific user, they previously could not because the user would be removed.

This patch adds a config option to preserve additional accounts and reworks the build script a little to make this it cleaner.


=====

The overarching purpose of this patch is that I want to run Avahi, so I can use mDNS to connect to hosts. 