### PR TITLE
fix corrupted plain_unit_concat function

### DIFF
--- a/src/mkinitcpio-install.sh
+++ b/src/mkinitcpio-install.sh
@@ -71,7 +71,6 @@ plain_unit_concat() {
     local unit_content=""
     local service_path=""
     local override_path=""
-    plain "using synthetic concat for $unit_name"
     # add the top-most service
     for service_path in {/usr/lib,/etc}/systemd/system ; do
         if [[ -f "${service_path}/${unit_name}" ]] ; then


### PR DESCRIPTION
In environments where "systemctl cat" is not available the fallback function `plain_unit_concat` is being used. That function corrupts the generated unit file because it does print "using synthetic concat for <unitname>" to stdout which will then be the first line in the generated unit file,, see this code in mkinitcpio-install.sh:
`plain "using synthetic concat for $unit_name"`

This makes the syntax of the unit file invalid and thus breaks it. Since this is only a technical message with very low value, I have opted to remove it.