### PR TITLE
Fixes #120 - Flattening argv errors on leaked shopts from mkinitcpio

### DIFF
--- a/src/initrd-build.sh
+++ b/src/initrd-build.sh
@@ -111,8 +111,14 @@ keypath_dropbear() {
 
 # safety wrapper for external commands
 run_command() {
-    local command="$@"
-    local result ; result=$(2>&1 $command) ; status=$?
+    local command result status
+
+    printf -v command '%q ' "$@"
+    command=${command% }
+
+    result=$("$@" 2>&1)
+    status=$?
+
     case "$status" in
          0) quiet "command success: $command\n$result\n" ; return 0 ;;
          *) error "command failure ($status): $command \n$result\n" ; return 1 ;;  


### PR DESCRIPTION
This PR fixes the `argv` flattening by separating "what to execute" and the logging of it:

`"$@"` - the real command `argv`, used for execution
`command` - a printable representation of `$@`, used only for logs

PR #119 is a related but incomplete re-implementation of the `sed` workflow.

### Background
`mkinitcpio` v41 introduced a bug where `nullglob` was set globally and not reset: [4d516794](https://gitlab.archlinux.org/qwertviop/mkinitcpio/-/commit/4d51679443638342ff8630ecddfcacf17ead0cd6)

Fixed in: [0647e9f0](https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/commit/0647e9f01b36bbabb9ce1459dfa7303419eeb114)