### PR TITLE
initrd-shell: fix await_condition command execution

### DIFF
--- a/src/initrd-shell.sh
+++ b/src/initrd-shell.sh
@@ -114,13 +114,18 @@ clear_console_input() {
 
 # invoke operation within a timeout
 await_condition() {
-    local command="$*" count=1
+    local count=1
     while true ; do
-        $command && return 0
+        "$@" && return 0
         sleep "$sleep_delay" ; count=$((count+1))
         [[ "$count" -gt "$sleep_count" ]] && return 1
     done
 }
+
+has_no_crypt_jobs() {
+ ! has_crypt_jobs
+}
+
 
 # get a portion of current console output
 read_console_tail() {
@@ -150,7 +155,7 @@ await_request_present() {
 
 # ensure secret was correct (crypto jobs are gone)
 await_secret_validated() {
-    await_condition [[ ! has_crypt_jobs ]]
+    await_condition has_no_crypt_jobs
 }
 
 # query password from the terminal or plymouth


### PR DESCRIPTION
This fixes #122 which identifies two related bugs in the initrd runtime shell path:

1. `await_condition()` flattens its command arguments into a scalar with `local command="$*"` and later executes `$command` unquoted. This loses `argv` boundaries and makes the condition sensitive to word splitting and pathname expansion.

2. `await_secret_validated()` passes `[[ ! has_crypt_jobs ]]` as if it were a command. That does not call `has_crypt_jobs`; inside `[[ ... ]]`,    `has_crypt_jobs` is a non-empty string, so the expression is always false.

The fix is to execute `"$@"` directly in `await_condition()` and introduce a small `has_no_crypt_jobs()` predicate for the negated condition.