### PR TITLE
systemd 261 has added openssl as a requirement for systemd-resolved

### DIFF
--- a/src/initrd-network.service
+++ b/src/initrd-network.service
@@ -48,6 +48,7 @@ InitrdPath=/usr/lib/systemd/resolv.conf
 
 # dns resolution support
 InitrdBinary=/usr/lib/libnss_dns.so.2 optional=yes
+InitrdBinary=/usr/lib/libssl.so.3 optional=yes
 
 # required for systemd-resolved
 InitrdPath=/var/tmp/        create=yes


### PR DESCRIPTION
Adds InitrdBinary to the initrd-network.service file to be included in the initcpio archive.


Fixes #124 